### PR TITLE
chore: update version to 2.0.3 and add NPM authentication verificatio…

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,6 +85,11 @@ jobs:
       - name: Build package
         run: npm run build
 
+      - name: Verify NPM authentication
+        run: npm whoami --registry=https://registry.npmjs.org/
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
       - name: Publish to NPM
         run: npm publish --provenance --access public
         env:
@@ -121,11 +126,13 @@ jobs:
       - name: Build package
         run: npm run build
 
+      - name: Prepare scoped package name for GitHub Packages
+        run: npm pkg set name=@braian-quintian/express-version-api
+
       - name: Publish to GitHub Packages
-        run: npm publish
+        run: npm publish --registry=https://npm.pkg.github.com/
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        continue-on-error: true # Don't fail if GPR publish fails
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Update Release Notes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "express-version-api",
-  "version": "2.0.0",
+  "version": "2.0.3",
   "description": "Middleware for versioning routes/APIs in Express.js using semantic versioning like ^1.0 or ~1.2.",
   "author": "Braian Quintian <bquintian.developer@gmail.com>",
   "license": "MIT",


### PR DESCRIPTION
This pull request updates the release workflow and package metadata to improve the publishing process for both npmjs.org and GitHub Packages. The most significant changes include adding authentication verification for npm publishing, preparing the package for GitHub Packages with a scoped name, and updating the package version.

**Release workflow improvements:**

* Added a step to verify NPM authentication before publishing to npmjs.org by running `npm whoami` with the appropriate token.
* Updated the GitHub Packages publishing process to explicitly set the package name as scoped (`@braian-quintian/express-version-api`) and changed the publish command to use the GitHub registry.

**Package metadata:**

* Bumped the package version in `package.json` from `2.0.0` to `2.0.3`.